### PR TITLE
keystone: Make the secure memory address configurable.

### DIFF
--- a/sm-sbi-opensbi.c
+++ b/sm-sbi-opensbi.c
@@ -40,7 +40,8 @@ static int sbi_ecall_keystone_enclave_handler(unsigned long extid, unsigned long
       retval = sbi_sm_destroy_enclave(regs->a0);
       break;
     case SBI_SM_RUN_ENCLAVE:
-      retval = sbi_sm_run_enclave((struct sbi_trap_regs*) regs, regs->a0);
+      retval = sbi_sm_run_enclave((struct sbi_trap_regs*) regs, regs->a0,
+                                  regs->a1);
       __builtin_unreachable();
       break;
     case SBI_SM_RESUME_ENCLAVE:

--- a/sm-sbi.c
+++ b/sm-sbi.c
@@ -33,9 +33,11 @@ unsigned long sbi_sm_destroy_enclave(unsigned long eid)
   return ret;
 }
 
-unsigned long sbi_sm_run_enclave(struct sbi_trap_regs *regs, unsigned long eid)
+unsigned long sbi_sm_run_enclave(struct sbi_trap_regs *regs, unsigned long eid,
+                                 unsigned long secure_memory_addr)
 {
-  regs->a0 = run_enclave(regs, (unsigned int) eid);
+  run_enclave(regs, (unsigned int) eid);
+  regs->a0 = secure_memory_addr;
   regs->mepc += 4;
   sbi_trap_exit(regs);
   return 0;

--- a/sm-sbi.h
+++ b/sm-sbi.h
@@ -15,7 +15,8 @@ unsigned long
 sbi_sm_destroy_enclave(unsigned long eid);
 
 unsigned long
-sbi_sm_run_enclave(struct sbi_trap_regs *regs, unsigned long eid);
+sbi_sm_run_enclave(struct sbi_trap_regs *regs, unsigned long eid,
+                   unsigned long secure_memory_addr);
 
 unsigned long
 sbi_sm_exit_enclave(struct sbi_trap_regs *regs, unsigned long retval);


### PR DESCRIPTION
Update the interface of the `sbi_sm_run_enclave`, let us can pass the secure memory address to the OpenSBI.

---

Verification : 
--> bitstream : 241116-9d796505e5b-SERENGETI_ESWIN_REFERENCE_FP-HAPS100-jenkins-13796
--> script : /sifive-linux-tests/keystone_wg_test/run.sh keystone 0x7fe00000
We can pass the keystone test [[LINK](https://github.com/sifive/sifive-linux-tests/blob/dev/twu/optee/keystone_wg_test/scripts/keystone_wg_test.sh#L38)]